### PR TITLE
Bug fix in glp theme: consistent class name for header nav

### DIFF
--- a/wp-content/themes/glp/templates/nav-main.php
+++ b/wp-content/themes/glp/templates/nav-main.php
@@ -1,6 +1,6 @@
 <nav id="nav-main" role="navigation">
 	<div id="nav-main-inner" class="container">
-	<?php if (has_nav_menu('primary_header_navigation')) { wp_nav_menu(array('theme_location' => 'primary_header_navigation')); } ?>
+	<?php if (has_nav_menu('primary_header_navigation')) { wp_nav_menu(array('theme_location' => 'primary_header_navigation', 'container_class' => 'menu-primary-header-navigation-container')); } ?>
 	<?php if (has_nav_menu('social_navigation')) { wp_nav_menu(array('theme_location' => 'social_navigation')); } ?>
 	</div><!-- /#nav-main-inner -->
 </nav>


### PR DESCRIPTION
Make sure the "Primary Header Navigation" menu is always rendered with the same
class name "menu-primary-header-navigation-container" so that the correct style
gets applied.

Please refer to `wp_nav_menu` function documentation: https://github.com/WordPress/WordPress/blob/fc843ce4d0147d1851fa2e64ae7184f59a1b658b/wp-includes/nav-menu-template.php#L206
